### PR TITLE
[Bugfix] coveragerc in test container

### DIFF
--- a/docker-compose.shared.volumes.yml
+++ b/docker-compose.shared.volumes.yml
@@ -2,10 +2,10 @@ version: '3.7'
 services:
   nereid:
     volumes:
-      - $PROJECT_DATA_DIRECTORY:/nereid/nereid/data/project_data
+      - ${PROJECT_DATA_DIRECTORY:-./_project_data}:/nereid/nereid/data/project_data
   celeryworker:
     volumes:
-      - $PROJECT_DATA_DIRECTORY:/nereid/nereid/data/project_data
+      - ${PROJECT_DATA_DIRECTORY:-./_project_data}:/nereid/nereid/data/project_data
   nereid-tests:
     volumes:
-      - $PROJECT_DATA_DIRECTORY:/nereid/nereid/data/project_data
+      - ${PROJECT_DATA_DIRECTORY:-./_project_data}:/nereid/nereid/data/project_data

--- a/nereid/.coveragerc
+++ b/nereid/.coveragerc
@@ -5,3 +5,10 @@ branch = True
 omit =
     nereid/tests/*
     nereid/data/*
+
+[report]
+include = nereid/*.py
+ignore_errors = True
+omit =
+    nereid/tests/*
+    nereid/data/*

--- a/nereid/Dockerfile.multi
+++ b/nereid/Dockerfile.multi
@@ -88,6 +88,7 @@ RUN pip install \
   -r /requirements_tests.txt && \
   rm -rf /tsts/*
 COPY ./scripts/run-tests.sh /run-tests.sh
+COPY .coveragerc /.coveragerc
 RUN chmod +x /run-tests.sh
 ## This will make the container wait, doing nothing, but alive
 CMD ["bash", "-c", "while true; do sleep 1; done"]

--- a/nereid/Dockerfile.multi
+++ b/nereid/Dockerfile.multi
@@ -88,7 +88,7 @@ RUN pip install \
   -r /requirements_tests.txt && \
   rm -rf /tsts/*
 COPY ./scripts/run-tests.sh /run-tests.sh
-COPY .coveragerc /.coveragerc
+COPY .coveragerc /nereid/.coveragerc
 RUN chmod +x /run-tests.sh
 ## This will make the container wait, doing nothing, but alive
 CMD ["bash", "-c", "while true; do sleep 1; done"]


### PR DESCRIPTION
also cleaned up the volume mount pattern for the CI condition without a project directory environment variable.