### PR TITLE
[Feature] add ci job to test 'edge' requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,22 @@
+language: minimal
+dist: xenial
+
 env:
   global:
     - COMPOSE_FILE=docker-stack.yml
+
+matrix:
+  include:
+    - name: tests
+      env: 
+        - BUILD_SCRIPT_PATH=./scripts/build_dev.sh
+        - COVERAGE=true
+    - name: edge
+      env: 
+        - BUILD_SCRIPT_PATH=./scripts/build_edge.sh
+        - COVERAGE=false
+  allow_failures:
+    - name: edge
 
 before_install:
   - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
@@ -8,8 +24,10 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - docker-compose --version
-  - chmod +x ./scripts/build_dev.sh
-  - ./scripts/build_dev.sh
+
+install: 
+  - chmod +x ${BUILD_SCRIPT_PATH}
+  - bash ${BUILD_SCRIPT_PATH}
   - docker-compose up -d
   - docker-compose ps
 
@@ -17,9 +35,11 @@ script:
   - docker-compose exec nereid-tests pytest -v
 
 after_success:
-  - docker-compose exec nereid-tests coverage run -m pytest
-  - docker-compose exec nereid-tests coverage report -m 
-  - docker-compose exec nereid-tests coverage xml
-  - docker-compose exec nereid-tests cat /nereid/coverage.xml > coverage.xml
-  - docker-compose exec nereid-tests cat /nereid/.coverage > .coverage
-  - bash <(curl -s https://codecov.io/bash)
+  - if [ ${COVERAGE} = true ]; then
+      docker-compose exec nereid-tests coverage run -m pytest;
+      docker-compose exec nereid-tests coverage report -m;
+      docker-compose exec nereid-tests coverage xml;
+      docker-compose exec nereid-tests cat /nereid/coverage.xml > coverage.xml;
+      docker-compose exec nereid-tests cat /nereid/.coverage > .coverage;
+      bash <(curl -s https://codecov.io/bash);
+    fi

--- a/docker-compose.edge.build.yml
+++ b/docker-compose.edge.build.yml
@@ -1,0 +1,22 @@
+version: '3.7'
+services:
+  celeryworker:
+    build:
+      context: ./nereid
+      dockerfile: Dockerfile.multi
+      target: celeryworker-edge
+  nereid-tests:
+    build:
+      context: ./nereid
+      dockerfile: Dockerfile.multi
+      target: nereid-edge-tests
+  redis:
+    build:
+      context: ./nereid
+      dockerfile: Dockerfile.multi
+      target: redis
+  nereid:
+    build:
+      context: ./nereid
+      dockerfile: Dockerfile.multi
+      target: nereid

--- a/docker-compose.shared.volumes.yml
+++ b/docker-compose.shared.volumes.yml
@@ -2,10 +2,10 @@ version: '3.7'
 services:
   nereid:
     volumes:
-      - $PROJECT_DATA_DIRECTORY:/nereid/nereid/data/project_data
+      - ${PROJECT_DATA_DIRECTORY:-./_project_data}:/nereid/nereid/data/project_data
   celeryworker:
     volumes:
-      - $PROJECT_DATA_DIRECTORY:/nereid/nereid/data/project_data
+      - ${PROJECT_DATA_DIRECTORY:-./_project_data}:/nereid/nereid/data/project_data
   nereid-tests:
     volumes:
-      - $PROJECT_DATA_DIRECTORY:/nereid/nereid/data/project_data
+      - ${PROJECT_DATA_DIRECTORY:-./_project_data}:/nereid/nereid/data/project_data

--- a/nereid/Dockerfile.multi
+++ b/nereid/Dockerfile.multi
@@ -92,3 +92,20 @@ RUN chmod +x /run-tests.sh
 ## This will make the container wait, doing nothing, but alive
 CMD ["bash", "-c", "while true; do sleep 1; done"]
 EXPOSE 8888
+
+
+FROM python:3.7 as nereid-edge
+COPY requirements_edge.txt /requirements_edge.txt
+RUN pip install -r requirements_edge.txt
+COPY ./nereid /nereid/nereid
+WORKDIR /nereid
+ENV PYTHONPATH=/nereid
+
+FROM nereid-edge as nereid-edge-tests
+CMD ["bash", "-c", "while true; do sleep 1; done"]
+
+FROM nereid-edge as celeryworker-edge
+ENV C_FORCE_ROOT=1
+COPY ./scripts/run-worker.sh /run-worker.sh
+RUN chmod +x /run-worker.sh
+CMD ["bash", "/run-worker.sh"]

--- a/nereid/requirements_edge.txt
+++ b/nereid/requirements_edge.txt
@@ -1,0 +1,17 @@
+scipy
+pandas
+networkx
+pydot
+graphviz
+matplotlib
+fastapi
+aiofiles
+celery
+jinja2
+redis
+email-validator
+ujson
+pytest
+coverage
+codecov
+requests

--- a/scripts/build_edge.bat
+++ b/scripts/build_edge.bat
@@ -1,0 +1,13 @@
+
+set COMPOSE_FILE=docker-stack.yml
+
+call docker-compose ^
+-f docker-compose.shared.depends.yml ^
+-f docker-compose.shared.admin.yml ^
+-f docker-compose.shared.env.yml ^
+-f docker-compose.shared.volumes.yml ^
+-f docker-compose.dev.ports.yml ^
+-f docker-compose.edge.build.yml ^
+config > docker-stack.yml
+
+docker-compose -f docker-stack.yml build

--- a/scripts/build_edge.sh
+++ b/scripts/build_edge.sh
@@ -1,0 +1,13 @@
+set -e
+export COMPOSE_FILE=docker-stack.yml
+
+docker-compose \
+-f docker-compose.shared.depends.yml \
+-f docker-compose.shared.admin.yml \
+-f docker-compose.shared.env.yml \
+-f docker-compose.shared.volumes.yml \
+-f docker-compose.dev.ports.yml \
+-f docker-compose.edge.build.yml \
+config > docker-stack.yml
+
+docker-compose -f docker-stack.yml build


### PR DESCRIPTION
early warning of code rot, especially for fast moving projects like `starlette`, `fastapi`, and `pydantic`.